### PR TITLE
#8 Add subtitles to VLC

### DIFF
--- a/media_player.py
+++ b/media_player.py
@@ -84,8 +84,7 @@ class MediaPlayer():
                     "playlist_id": int(PLAYLIST_ID),
                     "media_player_id": int(MEDIA_PLAYER_ID),
                     "label_id": currently_playing_label_id,
-                    "playback_position": playback_position
-                    #"vlc_status": vlc_status
+                    "playback_position": playback_position,
                 }
 
                 # Publish to XOS broker


### PR DESCRIPTION
*Resolves issue #8*

Add subtitles to VLC.

### Acceptance Criteria
- [x] Get external `.srt` subtitles files playing via [VLC media players](https://github.com/ACMILabs/media-player-nuc)

### Relevant design files
Add a links to the relevant design files or leave as none.
* None

### Testing instructions
1. See the Optiplex 3070 running on Simon's desk - turn on the right hand monitor https://dashboard.balena-cloud.com/devices/3bb3238027e89fd0592c4f5309d2ac09/summary

**OR**

1. Install VLC and `pip3 install -r requirements.txt`
1. `cp config.tmpl.env config.env`
1. `source config.env`
1. `python3 media_player.py`

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- ~New logic has been documented~
- ~New logic has appropriate unit tests~
- ~Changelog has been updated if necessary~
- ~Deployment / migration instruction have been updated if required~