### PR TITLE
Add/2 better error message if vlc fails

### DIFF
--- a/media_player.py
+++ b/media_player.py
@@ -32,7 +32,7 @@ BALENA_SUPERVISOR_ADDRESS = os.getenv('BALENA_SUPERVISOR_ADDRESS')
 BALENA_SUPERVISOR_API_KEY = os.getenv('BALENA_SUPERVISOR_API_KEY')
 SENTRY_ID = os.getenv('SENTRY_ID')
 SUBTITLES = os.getenv('SUBTITLES', 'true')
-VLC_CONNECTION_RETRIES = int(os.getenv('VLC_CONNECTION_RETRIES', DOWNLOAD_RETRIES))
+VLC_CONNECTION_RETRIES = int(os.getenv('VLC_CONNECTION_RETRIES', '3'))
 
 # Setup Sentry
 sentry_sdk.init(SENTRY_ID)
@@ -52,7 +52,7 @@ class MediaPlayer():
     and update the message broker with its playback status.
     """
 
-    def __init__(self, vlc = None, playlist = [], current_playlist_position = 0, vlc_connection_attempts = 0):
+    def __init__(self, vlc=None, playlist=[], current_playlist_position=0, vlc_connection_attempts=0):
         self.vlc = vlc
         self.playlist = playlist
         self.current_playlist_position = current_playlist_position


### PR DESCRIPTION
*Resolves issue #2*

If VLC media player can't be reached, error message is enigmatic.

### Acceptance Criteria
- [x] Add better error message for failing to reach VLC media player status server
- [x] Add better error message for failing to read valid vlc_status data
- [x] Add better error message for an empty playlist from XOS

### Relevant design files
* None

### Testing instructions
1. Update Optiplex 3070 media player's `PLAYLIST_ID` to 50 and see errors to the console in Balena: https://dashboard.balena-cloud.com/devices/3bb3238027e89fd0592c4f5309d2ac09/envvars

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- ~[ ] New logic has been documented~
- ~[ ] New logic has appropriate unit tests~
- ~[ ] Changelog has been updated if necessary~
- ~[ ] Deployment / migration instruction have been updated if required~
