### PR TITLE
#31 Set default playlist ID to 1

### DIFF
--- a/media_player.py
+++ b/media_player.py
@@ -16,7 +16,7 @@ from kombu import Connection, Exchange, Queue
 import status_client
 
 XOS_PLAYLIST_ENDPOINT = os.getenv('XOS_PLAYLIST_ENDPOINT')
-PLAYLIST_ID = os.getenv('PLAYLIST_ID')
+PLAYLIST_ID = os.getenv('PLAYLIST_ID', '1')
 MEDIA_PLAYER_ID = os.getenv('MEDIA_PLAYER_ID')
 DOWNLOAD_RETRIES = int(os.getenv('DOWNLOAD_RETRIES', '3'))
 AMQP_URL = os.getenv('AMQP_URL')


### PR DESCRIPTION
* Updated the get `PLAYLIST_ID` with a default of 1 in case the Balena application does not have a default set