### PR TITLE
Run apt-get non-interactively.

### DIFF
--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.7.2
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
When running `docker-compose up --build` from within the development directory, I was getting prompted for a keyboard layout, which hangs since the docker build is non-interactive. Jason is also affected by this. This change stops apt-get from asking questions.