### PR TITLE
#57 Update environment variable from museumos-prod to xos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Error reporting:
 When booting up for the first time:
 
 * If you see the Balena loading image (a rounded cube), and don't see your device in Balena Cloud or XOS, then the media player probably doesn't have any internet access. Check the ethernet connection, and reboot the device.
-* If you see the ACMI logo on a black background, then the device has access to the internet and is trying to download video files from XOS. Check the Balena Cloud logs to verify that it's downloading the files you expect, large files take a little while to download. Also verify that you can reach the [XOS playlist API](https://museumos-prod.acmi.net.au/api/playlists/1/).
+* If you see the ACMI logo on a black background, then the device has access to the internet and is trying to download video files from XOS. Check the Balena Cloud logs to verify that it's downloading the files you expect, large files take a little while to download. Also verify that you can reach the [XOS playlist API](https://xos.acmi.net.au/api/playlists/1/).
 * If a default video starts playing with the title ACMI Media Player, then your device is running correctly and can access both XOS & Balena. You can now configure your device to load the content you'd like.
 
 ## Deploying via Balena for both x86 and ARM

--- a/config.tmpl.env
+++ b/config.tmpl.env
@@ -1,4 +1,4 @@
-export XOS_API_ENDPOINT="https://museumos-prod.acmi.net.au/api/"
+export XOS_API_ENDPOINT="https://xos.acmi.net.au/api/"
 export XOS_PLAYLIST_ID="1"
 export XOS_MEDIA_PLAYER_ID="1"
 export DOWNLOAD_RETRIES="3"

--- a/dev.tmpl.env
+++ b/dev.tmpl.env
@@ -1,4 +1,4 @@
-XOS_API_ENDPOINT=https://museumos-prod.acmi.net.au/api/
+XOS_API_ENDPOINT=https://xos.acmi.net.au/api/
 XOS_PLAYLIST_ID=1
 MEDIA_PLAYER_ID=31
 DOWNLOAD_RETRIES=3

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -39,7 +39,7 @@ def mocked_requests_get(*args, **kwargs):
         def raise_for_status(self):
             return None
 
-    if args[0].startswith('https://museumos-prod.acmi.net.au/api/playlists/'):
+    if args[0].startswith('https://xos.acmi.net.au/api/playlists/'):
         return MockResponse(file_to_string_strip_new_lines('data/playlist.json'), 200)
 
     return MockResponse(None, 404)


### PR DESCRIPTION
*Resolves issue #57*

Rename references from museumos-prod to xos.

### Acceptance Criteria
- [x] Rename references from https://museumos-prod.acmi.net.au to https://xos.acmi.net.au

### Relevant design files
* None

### Testing instructions
1. Once XOS has been updated, restart this media player and see that it connects to XOS: https://dashboard.balena-cloud.com/apps/1505457/devices

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- ~[ ] New logic has been documented~
- ~[ ] New logic has appropriate unit tests~
- ~[ ] Changelog has been updated if necessary~
- ~[ ] Deployment / migration instruction have been updated if required~
