### PR TITLE
#56 A media player can post its status without a label id.

### DIFF
--- a/media_player.py
+++ b/media_player.py
@@ -101,11 +101,16 @@ class MediaPlayer():
         stats = vlc.MediaStats()
         media.get_stats(stats)
         playlist_position = self.vlc['playlist'].index_of_item(media)
+        try:
+            label_id = self.playlist[playlist_position]['label']['id']
+        except TypeError:
+            # No label ID for this playlist item
+            label_id = None
         return {
             'datetime': self.datetime_now(),
             'playlist_id': int(XOS_PLAYLIST_ID),
             'media_player_id': int(XOS_MEDIA_PLAYER_ID),
-            'label_id': self.playlist[playlist_position]['label']['id'],
+            'label_id': label_id,
             'playlist_position': playlist_position,
             'playback_position': self.vlc['player'].get_position(),
             'dropped_audio_frames': stats.lost_abuffers,

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -110,6 +110,9 @@ def test_get_media_player_status(mixer, mixers):
                 'id': 456
             }
         },
+        {
+            'label': None
+        },
     ]
 
     mock_vlc_player = MagicMock()
@@ -119,8 +122,13 @@ def test_get_media_player_status(mixer, mixers):
     mock_vlc_playlist = MagicMock()
     mock_vlc_playlist.index_of_item = MagicMock(return_value=1)
     media_player.vlc['playlist'] = mock_vlc_playlist
-
     status = media_player.get_media_player_status()
+
+    mock_vlc_playlist.index_of_item = MagicMock(return_value=2)
+    media_player.vlc['playlist'] = mock_vlc_playlist
+    status_two = media_player.get_media_player_status()
+
     assert 'datetime' in status.keys()
     assert status['playlist_position'] == 1
     assert status['label_id'] == 456
+    assert status_two['label_id'] is None


### PR DESCRIPTION
*Resolves issue #56*

Ignore playlist items that don't have a video asset.

### Acceptance Criteria
- [x] filter playlist to remove items that don't have a video asset (it already was)
- [x] ensure label id isn't required for any actions (e.g. broadcasting position to RabbitMQ)

### Relevant design files
* None

### Testing instructions
1. Rebuild development: `cd development` and `docker-compose up --build`
1. Run tests: `docker exec -it mediaplayer make linttest`
1. See a playlist without a label running (on the projector): https://dashboard.balena-cloud.com/devices/bd312d46b0571b07d7adf8cf7bae75d2/summary
1. See the broker message has a null `label_id`: http://track.acmi.net.au:15672/#/queues/%2F/mqtt-subscription-playback_23 (and click Get Message(s) button)

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- ~[ ] New logic has been documented~
- ~[ ] New logic has appropriate unit tests~
- ~[ ] Changelog has been updated if necessary~
- ~[ ] Deployment / migration instruction have been updated if required~
