### PR TITLE
#94 Set a value for XDG_RUNTIME_DIR to avoid spamming the logs

### DIFF
--- a/scripts/pi.sh
+++ b/scripts/pi.sh
@@ -12,7 +12,14 @@ export DISPLAY=:0
 # Set the DBUS address for sending around system messages
 export DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
 
-# start desktop manager
+# Set XDG_RUNTIME_DIR
+mkdir -pv ~/.cache/xdgr
+export XDG_RUNTIME_DIR=$PATH:~/.cache/xdgr
+
+# Create Xauthority
+touch /root/.Xauthority
+
+# Start desktop manager
 echo "STARTING X"
 startx -- -nocursor &
 


### PR DESCRIPTION
*Resolves issue #94*

Set a value for `XDG_RUNTIME_DIR` to avoid spamming the logs to make debugging easier.

### Acceptance Criteria
- [x] Set a value for `XDG_RUNTIME_DIR` to avoid filling the logs with spam

### Relevant design files
* None

### Testing instructions
1. Set that the logs for [e__media-player-pi-4 > DD-00-AV10A-RP01](https://dashboard.balena-cloud.com/devices/d2ae4da2db7e80361dba67757196444c/summary) aren't spammed with errors.

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- ~[ ] New logic has been documented~
- ~[ ] New logic has appropriate unit tests~
- ~[ ] Changelog has been updated if necessary~
- ~[ ] Deployment / migration instruction have been updated if required~
