### PR TITLE
#75 sentry spam

### DIFF
--- a/scripts/pi.sh
+++ b/scripts/pi.sh
@@ -21,7 +21,7 @@ touch /root/.Xauthority
 
 # Start desktop manager
 echo "STARTING X"
-startx -- :0 &
+startx -- -nocursor &
 
 # TODO: work out how to detect X has started
 sleep 5


### PR DESCRIPTION
*Resolves issue #75 & #76*

Don't spam Sentry when a Playlist doesn't exist. Fix the Balena API call to restart the container.

### Acceptance Criteria
- [x] Only log playlist problems after `VLC_CONNECTION_RETRIES` and only once
- [x] Fix f-string line-break in app container restart function

### Relevant design files
* None

### Testing instructions
1. Set a media_player's Playlist to `100` and see that it prints a suitable message and only posts to Sentry once: [young-dream](https://dashboard.balena-cloud.com/devices/a748935cacd55185ca832a69a837fd59/summary)

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- ~[ ] New logic has been documented~
- ~[ ] New logic has appropriate unit tests~
- ~[ ] Changelog has been updated if necessary~
- ~[ ] Deployment / migration instruction have been updated if required~
