### PR TITLE
#1436 Deploy on master branch commits only

### DIFF
--- a/codefresh.yml
+++ b/codefresh.yml
@@ -39,3 +39,7 @@ steps:
       - balena login --token $BALENA_TOKEN
       - balena push s__media-player-x86
       - balena push s__media-player-pi-4
+    when:
+      branch:
+        only:
+          - master


### PR DESCRIPTION
Resolves ACMILabs/xos#1436

- Made codefresh deploy to balena only on master pushes

### Acceptance Criteria
- [X] Deploy to balena only on master pushes

### Relevant design files
* None

### Testing instructions
1. Check that the push on this branch did not deploy https://g.codefresh.io/build/5e6732861a9939859c192f9c. Alternatively, make an empty commit and push to this branch `git commit --allow-empty -m "#1436 Trigger codefresh"` and check that it doesn't deploy
2. On merge we can check that it deploys on master (it worked on playlist label: https://g.codefresh.io/build/5e6730b909e1bcaeb2b21b30?step=deploy_to_Balena&tab=output)

### DoD
For requester to complete:
- [X] All acceptance criteria are met
~New logic has been documented~
~New logic has appropriate unit tests~
~Changelog has been updated if necessary~
~Deployment / migration instruction have been updated if required~
