### PR TITLE
#127 Add screen width, height and frames-per-second settings for x86

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ SUBTITLES # Set to true will display subtitles
 SUBTITLES_FONT_SIZE # Set a subtitle size value of 0-4096
 SUBTITLES_FONT_WEIGHT # Set the font weight to regular or bold
 DEBUG # Set to true to see more output on the console
-
+SCREEN_WIDTH # Set the screen width
+SCREEN_HEIGHT # Set the screen height
+FRAMES_PER_SECOND # Set the screen refresh rate
 ```
 
 ### Endpoints

--- a/scripts/pi.sh
+++ b/scripts/pi.sh
@@ -54,10 +54,18 @@ if [[ ! -z "$ROTATE_DISPLAY" ]]; then
   (sleep 3 && xrandr -o $ROTATE_DISPLAY) &
 fi
 
-# Parse screen resolution for smaller screens
-export SCREEN_WIDTH=`xrandr -q | awk -F'current' -F',' 'NR==1 {gsub("( |current)","");print $2}' | cut -d 'x' -f1`
-export SCREEN_HEIGHT=`xrandr -q | awk -F'current' -F',' 'NR==1 {gsub("( |current)","");print $2}' | cut -d 'x' -f2`
-echo "Display resolution: ${SCREEN_WIDTH}x${SCREEN_HEIGHT}"
+# Set or parse screen resolution
+if [[ ! -z "$SCREEN_WIDTH" ]] && [[ ! -z "$SCREEN_HEIGHT" ]] && [[ ! -z "$FRAMES_PER_SECOND" ]]; then
+  echo "Setting screen to: ${SCREEN_WIDTH}x${SCREEN_HEIGHT} @${FRAMES_PER_SECOND}"
+  xrandr -s "$SCREEN_WIDTH"x"$SCREEN_HEIGHT" -r $FRAMES_PER_SECOND
+elif [[ ! -z "$SCREEN_WIDTH" ]] && [[ ! -z "$SCREEN_HEIGHT" ]]; then
+  echo "Setting screen to: ${SCREEN_WIDTH}x${SCREEN_HEIGHT}"
+  xrandr -s "$SCREEN_WIDTH"x"$SCREEN_HEIGHT"
+else
+  export SCREEN_WIDTH=`xrandr -q | awk -F'current' -F',' 'NR==1 {gsub("( |current)","");print $2}' | cut -d 'x' -f1`
+  export SCREEN_HEIGHT=`xrandr -q | awk -F'current' -F',' 'NR==1 {gsub("( |current)","");print $2}' | cut -d 'x' -f2`
+  echo "Screen resolution parsed as: ${SCREEN_WIDTH}x${SCREEN_HEIGHT}"
+fi
 
 # Unmute system audio
 # ./scripts/unmute.sh

--- a/scripts/x86.sh
+++ b/scripts/x86.sh
@@ -67,7 +67,7 @@ if [[ ! -z "$ROTATE_DISPLAY" ]]; then
   (sleep 3 && xrandr -o $ROTATE_DISPLAY) &
 fi
 
-# Set display size and frames-per-second
+# Set display size and frames-per-second refresh rate
 # Note: SCREEN_WIDTH and SCREEN_HEIGHT also tell VLC to play the video at that size too
 if [[ ! -z "$SCREEN_WIDTH" ]] && [[ ! -z "$SCREEN_HEIGHT" ]] && [[ ! -z "$FRAMES_PER_SECOND" ]]; then
   echo "Setting screen to: ${SCREEN_WIDTH}x${SCREEN_HEIGHT} @${FRAMES_PER_SECOND}"

--- a/scripts/x86.sh
+++ b/scripts/x86.sh
@@ -67,8 +67,15 @@ if [[ ! -z "$ROTATE_DISPLAY" ]]; then
   (sleep 3 && xrandr -o $ROTATE_DISPLAY) &
 fi
 
-# Set display to 4K
-# xrandr --output HDMI-1 --mode 3840x2160
+# Set display size and frames-per-second
+# Note: SCREEN_WIDTH and SCREEN_HEIGHT also tell VLC to play the video at that size too
+if [[ ! -z "$SCREEN_WIDTH" ]] && [[ ! -z "$SCREEN_HEIGHT" ]] && [[ ! -z "$FRAMES_PER_SECOND" ]]; then
+  echo "Setting screen to: ${SCREEN_WIDTH}x${SCREEN_HEIGHT} @${FRAMES_PER_SECOND}"
+  xrandr -s "$SCREEN_WIDTH"x"$SCREEN_HEIGHT" -r $FRAMES_PER_SECOND
+elif [[ ! -z "$SCREEN_WIDTH" ]] && [[ ! -z "$SCREEN_HEIGHT" ]]; then
+  echo "Setting screen to: ${SCREEN_WIDTH}x${SCREEN_HEIGHT}"
+  xrandr -s "$SCREEN_WIDTH"x"$SCREEN_HEIGHT"
+fi
 
 # Unmute system audio
 # ./scripts/unmute.sh


### PR DESCRIPTION
Resolves #127

Add screen width, height and frames-per-second settings for x86 media players so that their output is compatible with Panasonic TH-86EQ1W 4K screens.

### Acceptance Criteria
- [x] Add `SCREEN_WIDTH`, `SCREEN_HEIGHT` and `FRAMES_PER_SECOND` media player environment variables to x86 players to force a resolution

### Relevant design files
* None

### Testing instructions
1. Visit [MA-04-AV01-PC01](https://dashboard.balena-cloud.com/devices/02bd997951d08ecbb9e58a75fc9b71ef37fbd978b623f379d665a27d527b53/summary)
1. See that the variables `SCREEN_WIDTH`, `SCREEN_HEIGHT` and `FRAMES_PER_SECOND` are set
1. Note that they're echo'd in the logs when the media player `main` service is restarted
1. Check with Evan that its displaying correctly in the gallery
1. **TODO**: get a raspberry pi media player example to add to an experimental repo to make sure it works there too

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- ~[ ] New logic has been documented~
- ~[ ] New logic has appropriate unit tests~
- [ ] Changelog has been updated if necessary
- ~[ ] Deployment / migration instruction have been updated if required~
