### PR TITLE
#134 Handle alsaaudio exception when getting system volume

### DIFF
--- a/media_player.py
+++ b/media_player.py
@@ -206,7 +206,7 @@ class MediaPlayer():
             try:
                 system_volume = str(alsaaudio.Mixer(alsaaudio.mixers()[0]).getvolume()[0] / 10)
             except alsaaudio.ALSAAudioError:
-                system_volume = None
+                system_volume = 0
             media_player_status = {
                 'datetime': self.datetime_now(),
                 'playlist_id': int(XOS_PLAYLIST_ID),

--- a/media_player.py
+++ b/media_player.py
@@ -203,6 +203,10 @@ class MediaPlayer():
             except TypeError:
                 # No label ID for this playlist item
                 label_id = None
+            try:
+                system_volume = str(alsaaudio.Mixer(alsaaudio.mixers()[0]).getvolume()[0] / 10)
+            except alsaaudio.ALSAAudioError:
+                system_volume = None
             media_player_status = {
                 'datetime': self.datetime_now(),
                 'playlist_id': int(XOS_PLAYLIST_ID),
@@ -218,7 +222,7 @@ class MediaPlayer():
                 str(self.vlc['player'].audio_get_volume() / 256 * 10),
                 'system_volume': \
                 # System value 0-100
-                str(alsaaudio.Mixer(alsaaudio.mixers()[0]).getvolume()[0] / 10),
+                system_volume,
             }
         else:
             # playlist is empty


### PR DESCRIPTION
Resolves #134

Handle `alsaaudio.ALSAAudioError` when getting the system volume to aid debugging. This should allow us to do some more diagnostics around the Alsa bug without having the media player container boot loop.

### Acceptance Criteria
- [x] Handle `alsaaudio.ALSAAudioError` when getting the system volume to aid debugging

### Relevant design files
* None

### Testing instructions
1. See that ~[RP10](https://dashboard.balena-cloud.com/devices/167112f5532a8dad8dc414e598e2ee6c/summary)~ [RP05](https://dashboard.balena-cloud.com/devices/96e4cf749695017328ab3dec60cc2adc/summary) isn't in a boot loop and you can open a Terminal okay
1. Note that playback is progressing: http://172.16.82.251:1007

([RP10](https://dashboard.balena-cloud.com/devices/167112f5532a8dad8dc414e598e2ee6c/summary) seems to have a faulty/slow SD card and is failing to download the app image)

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- ~[ ] New logic has been documented~
- ~[ ] New logic has appropriate unit tests~
- [ ] Changelog has been updated if necessary
- ~[ ] Deployment / migration instruction have been updated if required~
