### PR TITLE
#137 Reduce time between retries to connect to sync host server

### DIFF
--- a/network.py
+++ b/network.py
@@ -71,8 +71,8 @@ class Client:  # pylint: disable=R0903
                 print(f'Waiting for server at {address} port {port}')
                 time.sleep(1)
             except OSError:
-                print(f'Can\'t connect to {address} port {port}... retrying in 1 minute')
-                time.sleep(60)
+                print(f'Can\'t connect to {address} port {port}')
+                time.sleep(1)
 
     def receive(self):
         """


### PR DESCRIPTION
Resolves #137

Investigate why synced media players need to be rebooted a few times to sync successfully.

### Acceptance Criteria
- [x] Reduce retry to 1 second when a sync client can't connect to a sync server because of an `OSError`

### Relevant design files
* None

### Testing instructions
1. Reboot [The Core](https://dashboard.balena-cloud.com/apps/1502308/devices) (filter `MM-10-AV01`) devices and see that they come online and sync quickly

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- ~[ ] New logic has been documented~
- ~[ ] New logic has appropriate unit tests~
- ~[ ] Changelog has been updated if necessary~
- ~[ ] Deployment / migration instruction have been updated if required~
