### PR TITLE
#139 Fix synced media player server exception when clients are added while sending time data

### DIFF
--- a/network.py
+++ b/network.py
@@ -42,13 +42,19 @@ class Server:
         """
         data = '{},'.format(data).encode()
 
-        for client in self.clients:
-            try:
-                client.send(data)
-            except socket.error:
-                print(f'Connection to client: {client} was broken!')
-                client.close()
-                self.clients.remove(client)
+        try:
+            for client in self.clients:
+                try:
+                    client.send(data)
+                except socket.error:
+                    print(f'Connection to client: {client} was broken!')
+                    client.close()
+                    self.clients.remove(client)
+        except RuntimeError as exception:
+            # e.g. #139 RuntimeError: Set changed size during iteration
+            # We're sending this time data every 1 second, so okay to skip a few as clients arrive
+            # If it becomes a problem, write a locking mechanism for listen_for_clients()
+            print(f'Media Player Server exception while trying to send {data}: {exception}')
 
 
 class Client:  # pylint: disable=R0903


### PR DESCRIPTION
Resolves #139

Handle exception when a sync server's set of clients changes size while it is sending the time data to all of its clients.

### Acceptance Criteria
- [x] Handle `RuntimeError` gracefully so server can accept connection and client tries again

### Relevant design files
* None

### Testing instructions
1. Reboot all synced media players and see that no exceptions occur on cold boot and initial sync

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- ~[ ] New logic has been documented~
- ~[ ] New logic has appropriate unit tests~
- [ ] Changelog has been updated if necessary
- ~[ ] Deployment / migration instruction have been updated if required~
