### PR TITLE
#70 Handle synced media player clients re-connecting when servers restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Optional variables:
 
 ```.env
 SYNC_DRIFT_THRESHOLD # Defaults to 40. (milliseconds)
+SYNC_LATENCY # Defaults to 30. (milliseconds)
 SUBTITLES # Set to true will display subtitles
 SUBTITLES_FONT_SIZE # Set a subtitle size value of 0-4096
 SUBTITLES_FONT_WEIGHT # Set the font weight to regular or bold
@@ -179,4 +180,10 @@ To setup a user:
 The address of the AMQP service is then: `amqp://username:password@172.16.80.105:5672//`
 
 ## Synchronised Playback
-Several media players may be configured to play video files of the exact same length in synchronised time with each other. This is done be setting one media player to be the 'synchronisation server', by setting the config variable `SYNC_IS_SERVER` to True. The remaining media players should be set to track the server by setting the config variable `SYNC_CLIENT_TO` to the IP address of the synchronisation server. 
+
+Several media players may be configured to play video files of the exact same length in synchronised time with each other. This is done be setting one media player to be the 'synchronisation server', by setting the config variable `SYNC_IS_SERVER` to True. The remaining media players should be set to track the server by setting the config variable `SYNC_CLIENT_TO` to the IP address of the synchronisation server.
+
+To tune the synchronisation settings, try these optional variables:
+
+* `SYNC_DRIFT_THRESHOLD` - the number of milliseconds playback difference between the server and client before attempting to re-sync the playback
+* `SYNC_LATENCY` - the number of milliseconds your hardware device takes to seek the new playback position

--- a/media_player.py
+++ b/media_player.py
@@ -547,10 +547,22 @@ class MediaPlayer():
             while True:
                 server_time = self.client.receive()
                 if not server_time:
-                    if DEBUG:
-                        print('No server_time received, attempting to re-setup sync...')
-                    self.setup_sync()
+                    self.client.sync_attempts += 1
+                    if self.client.sync_attempts > 3:
+                        if DEBUG:
+                            print('No server_time received, attempting to re-setup sync...')
+                        self.setup_sync()
+                        if DEBUG:
+                            print(f'Sync attempts reset to: {self.client.sync_attempts}')
+                    else:
+                        if DEBUG:
+                            print(
+                                'No server_time received, sync_attempts: '
+                                f'{self.client.sync_attempts}'
+                            )
                     continue
+                else:
+                    self.client.sync_attempts = 0
                 client_time = self.get_current_time()
                 if DEBUG:
                     print(

--- a/media_player.py
+++ b/media_player.py
@@ -40,6 +40,7 @@ VLC_CONNECTION_RETRIES = int(os.getenv('VLC_CONNECTION_RETRIES', '3'))
 SYNC_CLIENT_TO = os.getenv('SYNC_CLIENT_TO')
 SYNC_IS_SERVER = os.getenv('SYNC_IS_SERVER', 'false') == 'true'
 SYNC_DRIFT_THRESHOLD = os.getenv('SYNC_DRIFT_THRESHOLD', '40')  # threshold in milliseconds
+SYNC_LATENCY = os.getenv('SYNC_DRIFT_THRESHOLD', '30')  # latency to sync a client in milliseconds
 IS_SYNCED_PLAYER = SYNC_CLIENT_TO or SYNC_IS_SERVER
 DEBUG = os.getenv('DEBUG', 'false') == 'true'
 SCREEN_WIDTH = os.getenv('SCREEN_WIDTH')
@@ -559,8 +560,11 @@ class MediaPlayer():
                     )
                 if abs(client_time - server_time) > int(SYNC_DRIFT_THRESHOLD):
                     if DEBUG:
-                        print('Drifted, syncing...')
-                    self.vlc['player'].set_time(server_time)
+                        print(
+                            f'Drifted, syncing with server: {server_time} '
+                            f'plus sync latency of {SYNC_LATENCY}'
+                        )
+                    self.vlc['player'].set_time(server_time + int(SYNC_LATENCY))
 
         if SYNC_IS_SERVER:
             while True:

--- a/media_player.py
+++ b/media_player.py
@@ -546,6 +546,9 @@ class MediaPlayer():
             while True:
                 server_time = self.client.receive()
                 if not server_time:
+                    if DEBUG:
+                        print('No server_time received, attempting to re-setup sync...')
+                    self.setup_sync()
                     continue
                 client_time = self.get_current_time()
                 if DEBUG:
@@ -563,6 +566,8 @@ class MediaPlayer():
             while True:
                 time.sleep(1)
                 self.server.send(self.get_current_time())
+                if DEBUG:
+                    print(f'Clients: {self.server.clients}')
 
 
 if __name__ == "__main__":

--- a/media_player.py
+++ b/media_player.py
@@ -40,7 +40,7 @@ VLC_CONNECTION_RETRIES = int(os.getenv('VLC_CONNECTION_RETRIES', '3'))
 SYNC_CLIENT_TO = os.getenv('SYNC_CLIENT_TO')
 SYNC_IS_SERVER = os.getenv('SYNC_IS_SERVER', 'false') == 'true'
 SYNC_DRIFT_THRESHOLD = os.getenv('SYNC_DRIFT_THRESHOLD', '40')  # threshold in milliseconds
-SYNC_LATENCY = os.getenv('SYNC_DRIFT_THRESHOLD', '30')  # latency to sync a client in milliseconds
+SYNC_LATENCY = os.getenv('SYNC_LATENCY', '30')  # latency to sync a client in milliseconds
 IS_SYNCED_PLAYER = SYNC_CLIENT_TO or SYNC_IS_SERVER
 DEBUG = os.getenv('DEBUG', 'false') == 'true'
 SCREEN_WIDTH = os.getenv('SCREEN_WIDTH')

--- a/network.py
+++ b/network.py
@@ -68,6 +68,7 @@ class Client:  # pylint: disable=R0903
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.address = address
         self.port = port
+        self.sync_attempts = 0
         self.connect()
 
     def receive(self):

--- a/network.py
+++ b/network.py
@@ -66,19 +66,9 @@ class Client:  # pylint: disable=R0903
     def __init__(self, address, port):
 
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-
-        print(f'Connecting to {address} port {port}')
-        connected = False
-        while not connected:
-            try:
-                self.sock.connect((address, port))
-                connected = True
-            except ConnectionRefusedError:
-                print(f'Waiting for server at {address} port {port}')
-                time.sleep(1)
-            except OSError:
-                print(f'Can\'t connect to {address} port {port}')
-                time.sleep(1)
+        self.address = address
+        self.port = port
+        self.connect()
 
     def receive(self):
         """
@@ -91,8 +81,28 @@ class Client:  # pylint: disable=R0903
                 data = data.decode()
                 pos = data.split(',')[-2]
                 return int(pos)
+            print(f'No data received... {data}')
             return None
         except OSError:
             print(f'Closing socket: {self.sock}')
             self.sock.close()
+            print('Attempting to reconnect...')
+            self.connect()
             return None
+
+    def connect(self):
+        """
+        Attempt to connect to the server.
+        """
+        print(f'Connecting to {self.address} port {self.port}')
+        connected = False
+        while not connected:
+            try:
+                self.sock.connect((self.address, self.port))
+                connected = True
+            except ConnectionRefusedError:
+                print(f'Waiting for server at {self.address} port {self.port}')
+                time.sleep(1)
+            except OSError:
+                print(f'Can\'t connect to {self.address} port {self.port}')
+                time.sleep(1)


### PR DESCRIPTION
Resolves #70

Handle missing server_time messages on sync Clients and attempt to re-setup the sync with the server again.

### Acceptance Criteria
- [x] Handle Client sockets failing to return data, and re-establish a new socket with the server
- [x] Add optional `SYNC_LATENCY` environment variable to compensate for the time taken for the Client device to hit its sync playback position

### Relevant design files
Add a links to the relevant design files or leave as none.
* None

### Testing instructions
1. Open the Server [DD-00-AV10A-PC01](https://dashboard.balena-cloud.com/devices/b7c1c2917c84b9af70b934abb3572da4/summary)
1. Open the Client [DD-00-AV10B-PC01](https://dashboard.balena-cloud.com/devices/bc6c0e16570b60b7de7d31238d8c5960/summary)
1. On the Server, see the section: Services > Main > Tap the `Restart` (recycle icon)
1. Switch to the Client, see that it re-connects and the sync returns to a low number (< 10 seconds if we're lucky)
1. Now restart the Client: Services > Main > Tap the `Restart` (recycle icon)
1. See that it re-syncs, and see that the Server continues running

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- ~[ ] New logic has been documented~
- ~[ ] New logic has appropriate unit tests~
- [ ] Changelog has been updated if necessary
- ~[ ] Deployment / migration instruction have been updated if required~
