### PR TITLE
#144 Fix display detection

### DIFF
--- a/scripts/x86.sh
+++ b/scripts/x86.sh
@@ -35,7 +35,7 @@ DISPLAYS=`ps -u $(id -u) -o pid= | \
 echo $DISPLAYS
 
 # If DISPLAYS doesn't include 0.0 set the new display
-if [[ $DISPLAYS == *"0.0"* ]]; then
+if [[ $DISPLAYS == *":0.0"* ]]; then
   echo "Display includes 0.0 so let's launch..."
 else
   LAST_DISPLAY=`ps -u $(id -u) -o pid= | \


### PR DESCRIPTION
Resolves #144

Be more specific about display detection, :0.0 instead of just 0.0 so we don't match :10.0 and set the `DISPLAY` variable to the wrong display.

### Acceptance Criteria
- [x] Fix display detection bug so matched `DISPLAY=:10.0` doesn't set the display to `0.0`

### Relevant design files
* None

### Testing instructions
1. Reboot a media player 10x times, see that the display is correctly detected
1. OR start the media player container: `cd development` and `docker-compose up`
1. Bash into it: `docker exec -it mediaplayer bash`
1. Set `DISPLAYS` variable to the 10th start state: `export DISPLAYS="DISPLAY=:0 DISPLAY=:10 DISPLAY=:10.0"`
1. Note that the new fix doesn't match `:10.0` using this: `if [[ $DISPLAYS == *":0.0"* ]]; then echo "MATCHED"; fi;` (it will print `MATCHED` if you remove the `:` which demonstrates the previous bug

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- ~[ ] New logic has been documented~
- ~[ ] New logic has appropriate unit tests~
- [ ] Changelog has been updated if necessary
- ~[ ] Deployment / migration instruction have been updated if required~
