### PR TITLE
#136 Handle a playlist item without a video

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,12 +100,16 @@ The media player makes a get request to a playlist endpoint and expects a respon
     "playlist_labels": [
         {
             "label": {
-                "id": 44,
+                "id": 44
+            },
+            "video": {
+                "id": 12,
+                "resource": "MP4_VIDEO_FILE_URL"
             },
             "resource": "MP4_VIDEO_FILE_URL",
-            "subtitles": "SRT_SUBTITLE_FILE_URL",
-        },
-    ],
+            "subtitles": "SRT_SUBTITLE_FILE_URL"
+        }
+    ]
 }
 
 ```

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       dockerfile: development/Dockerfile
     hostname: mediaplayer
     container_name: mediaplayer
-    env_file: ../dev.env
+    env_file: ../dev.tmpl.env
     volumes:
       - ../:/code
     tty: true

--- a/media_player.py
+++ b/media_player.py
@@ -478,7 +478,7 @@ class MediaPlayer():
             for playlist_label in playlist_labels:
                 local_playlist_label = self.download_resources(playlist_label)
                 if not local_playlist_label:
-                    print(f'Invalid video resource: {playlist_label["resource"]}, skipping.')
+                    print(f'Invalid video resource: {playlist_label["video"]}, skipping.')
                     continue
                 local_resource = local_playlist_label['resource']
                 media = self.vlc['instance'].media_new(local_resource)

--- a/media_player.py
+++ b/media_player.py
@@ -447,7 +447,7 @@ class MediaPlayer():
         """
         playlist_json_data = {}
         try:
-            response = requests.get(XOS_PLAYLIST_ENDPOINT + XOS_PLAYLIST_ID, timeout=5)
+            response = requests.get(XOS_PLAYLIST_ENDPOINT + XOS_PLAYLIST_ID + '/', timeout=5)
             response.raise_for_status()
             playlist_json_data = response.json()
 

--- a/tests/data/playlist.json
+++ b/tests/data/playlist.json
@@ -20,6 +20,39 @@
           }
         ]
       },
+      "video": {
+        "id": 2,
+        "title": "sample.mp4",
+        "resource": "file://../../data/resources/sample.mp4",
+        "web_resource": "file://../../data/resources/sample.mp4",
+        "duration_secs": 20.204,
+        "subtitles": null,
+        "master_metadata": null,
+        "access_metadata": null,
+        "web_metadata": {
+          "width": 1920,
+          "height": 1080,
+          "checksum": "ea28ad0b8ef30ee436c485d7a00b830d",
+          "mime_type": "video/mp4",
+          "audio_codec": null,
+          "video_codec": "h264",
+          "duration_hms": "00:20",
+          "duration_secs": 20.204,
+          "audio_bit_rate": null,
+          "audio_channels": null,
+          "video_bit_rate": 43369,
+          "file_size_bytes": 124897,
+          "overall_bit_rate": 49454,
+          "video_frame_rate": 59.94005994005994,
+          "audio_sample_rate": null,
+          "creation_datetime": "2020-09-28 11:50:48.737992",
+          "audio_max_bit_rate": null,
+          "video_max_bit_rate": null
+        },
+        "access_level": "No access",
+        "snapshot": "file://../../data/resources/sample.jpg",
+        "animated_snapshot": ""
+      },
       "resource": "file://../../data/resources/sample.mp4",
       "subtitles": "file://../../data/resources/sample.srt"
     },
@@ -40,6 +73,39 @@
             "first_production_year": "1993"
           }
         ]
+      },
+      "video": {
+        "id": 2,
+        "title": "sample.mp4",
+        "resource": "file://../../data/resources/sample.mp4",
+        "web_resource": "file://../../data/resources/sample.mp4",
+        "duration_secs": 20.204,
+        "subtitles": null,
+        "master_metadata": null,
+        "access_metadata": null,
+        "web_metadata": {
+          "width": 1920,
+          "height": 1080,
+          "checksum": "ea28ad0b8ef30ee436c485d7a00b830d",
+          "mime_type": "video/mp4",
+          "audio_codec": null,
+          "video_codec": "h264",
+          "duration_hms": "00:20",
+          "duration_secs": 20.204,
+          "audio_bit_rate": null,
+          "audio_channels": null,
+          "video_bit_rate": 43369,
+          "file_size_bytes": 124897,
+          "overall_bit_rate": 49454,
+          "video_frame_rate": 59.94005994005994,
+          "audio_sample_rate": null,
+          "creation_datetime": "2020-09-28 11:50:48.737992",
+          "audio_max_bit_rate": null,
+          "video_max_bit_rate": null
+        },
+        "access_level": "No access",
+        "snapshot": "file://../../data/resources/sample.jpg",
+        "animated_snapshot": ""
       },
       "resource": "file://../../data/resources/sample.mp4",
       "subtitles": "file://../../data/resources/sample.srt"
@@ -62,8 +128,61 @@
           }
         ]
       },
+      "video": {
+        "id": 2,
+        "title": "sample.mp4",
+        "resource": "file://../../data/resources/sample.mp4",
+        "web_resource": "file://../../data/resources/sample.mp4",
+        "duration_secs": 20.204,
+        "subtitles": null,
+        "master_metadata": null,
+        "access_metadata": null,
+        "web_metadata": {
+          "width": 1920,
+          "height": 1080,
+          "checksum": "ea28ad0b8ef30ee436c485d7a00b830d",
+          "mime_type": "video/mp4",
+          "audio_codec": null,
+          "video_codec": "h264",
+          "duration_hms": "00:20",
+          "duration_secs": 20.204,
+          "audio_bit_rate": null,
+          "audio_channels": null,
+          "video_bit_rate": 43369,
+          "file_size_bytes": 124897,
+          "overall_bit_rate": 49454,
+          "video_frame_rate": 59.94005994005994,
+          "audio_sample_rate": null,
+          "creation_datetime": "2020-09-28 11:50:48.737992",
+          "audio_max_bit_rate": null,
+          "video_max_bit_rate": null
+        },
+        "access_level": "No access",
+        "snapshot": "file://../../data/resources/sample.jpg",
+        "animated_snapshot": ""
+      },
       "resource": "file://../../data/resources/sample.mp4",
       "subtitles": "file://../../data/resources/sample.srt"
+    },
+    {
+      "label": {
+        "id": 666,
+        "title": "No video or resource",
+        "description": "A label without a video or a resource",
+        "publication": "1989, Dir. Hayao Miyazaki",
+        "rights": "",
+        "works": [
+          {
+            "id": 48,
+            "title": "Kiki's Delivery Service",
+            "image": "file://../../data/resources/sample.jpg",
+            "abstract": "",
+            "brief_description": "A label without a video or a resource",
+            "first_production_year": "1989"
+          }
+        ]
+      },
+      "video": null
     }
   ]
 }


### PR DESCRIPTION
Resolves #136

Ignores an XOS Playlist item that doesn't have a video or a video resource.

### Acceptance Criteria
- [x] Handle a Playlist with an empty `video` resource

### Relevant design files
* None

### Testing instructions
1. Add your media player to: https://dashboard.balena-cloud.com/apps/1505457/devices
2. Point it at your local development environment that has a Playlist with an item that doesn't have a video, and see that the other videos in that Playlist play

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- [x] New logic has been documented
- [x] New logic has appropriate unit tests
- [ ] Changelog has been updated if necessary
- ~[ ] Deployment / migration instruction have been updated if required~
