### PR TITLE
#147 Add GitHub Actions to run Python tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: Media Player CI
+
+on: [push]
+
+jobs:
+  build-and-test-python:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build Python lint and test
+      run: |
+        cd development && docker-compose up --build -d
+    - name: Run Python lint and test
+      run: docker exec mediaplayer make linttest

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ lint:
     # Lint the code and check imports have been sorted correctly
 	pylint *
 	flake8
-	isort -rc --check-only .
+	isort --check-only .
 test:
 	# Run tests
 	pytest -v -s

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Media player
 
 A media player using Python to launch and control VLC on low-cost hardware.
 
+![Media Player CI](https://github.com/ACMILabs/media-player/workflows/Media%20Player%20CI/badge.svg)
+
 ## Features:
 * Runs on Raspberry Pi 4 and Intel small-form-factor PCs.
 * Downloads a playlist of videos (with optional subtitles) from XOS and saves these locally so that playback can take place after reboot without an internet connection
@@ -51,12 +53,18 @@ We use small-form-factor PCs such as Dell Optiplex Micro or Intel NUC in places 
 ## Installation on developer machine
 
 * Clone this repository.
-
-* `$ cd development`
-* Build the development container `$ docker-compose up`
+* Build the development container `$ cd development` and `$ docker-compose up --build`
 * `cp dev.tmpl.env dev.env`
 * Edit the `dev.env` with any required values (a default playlist will be used otherwise)
 * Run `cd development && docker-compose up`
+
+### Rebuild the development base image
+
+If you change any of the requirements you'll need to re-build the development container's base image `acmilabs/mediaplayer-development:v1`, it's built from `development/Dockerfile.development`. To re-build it run:
+
+Re-build it: `docker build --file development/Dockerfile.development -t acmilabs/mediaplayer-development:v1 .`
+
+Push the new image to Docker Hub: `docker push acmilabs/mediaplayer-development:v1`
 
 ## Testing and linting
 

--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -1,30 +1,8 @@
-FROM python:3.8
-
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update \
-    && apt-get upgrade -y --no-install-recommends \
-    && apt-get install -y --no-install-recommends \
-        vlc vlc-plugin-* g++ \
-        xserver-xorg \
-        xserver-xorg-input-evdev \
-        xinit \
-        xfce4 \
-        xfce4-terminal \
-        x11-xserver-utils \
-        dbus-x11 \
-        matchbox-keyboard \
-        xterm \
-        # For system volume
-        libasound2-dev \
-        # Audio
-        alsa-utils
-
-# Intel GPU drivers for VLC
-ARG IS_X86
-RUN if [ "$IS_X86" = "true" ]; \
-  then install_packages i965-va-driver vainfo; \
-  fi
+# Built from Dockerfile.development
+# To rebuild:
+# docker build --file development/Dockerfile.development -t acmilabs/mediaplayer-development:v1 .
+# docker push acmilabs/mediaplayer-development:v1
+FROM acmilabs/mediaplayer-development:v1
 
 # Disable screen from turning it off
 RUN echo "#!/bin/bash" > /etc/X11/xinit/xserverrc \

--- a/development/Dockerfile.development
+++ b/development/Dockerfile.development
@@ -1,0 +1,27 @@
+FROM python:3.8
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get upgrade -y --no-install-recommends \
+    && apt-get install -y --no-install-recommends \
+        vlc vlc-plugin-* g++ \
+        xserver-xorg \
+        xserver-xorg-input-evdev \
+        xinit \
+        xfce4 \
+        xfce4-terminal \
+        x11-xserver-utils \
+        dbus-x11 \
+        matchbox-keyboard \
+        xterm \
+        # For system volume
+        libasound2-dev \
+        # Audio
+        alsa-utils
+
+# Intel GPU drivers for VLC
+ARG IS_X86
+RUN if [ "$IS_X86" = "true" ]; \
+  then install_packages i965-va-driver vainfo; \
+  fi

--- a/media_player.py
+++ b/media_player.py
@@ -67,7 +67,7 @@ CACHED_PLAYLIST_JSON = '/data/cached_playlist.json'
 APLAY_REGEX = re.compile(r'card (?P<card_id>\d+): (.+), device (?P<device_id>\d+): (.+)')
 
 
-class MediaPlayer():
+class MediaPlayer():  # pylint: disable=too-many-branches
     """
     A media player that communicates with XOS to download resources
     and update the message broker with its playback status.
@@ -546,7 +546,9 @@ class MediaPlayer():
         if SYNC_CLIENT_TO:
             while True:
                 server_time = self.client.receive()
-                if not server_time:
+                if server_time:
+                    self.client.sync_attempts = 0
+                else:
                     self.client.sync_attempts += 1
                     if self.client.sync_attempts > 3:
                         if DEBUG:
@@ -561,8 +563,6 @@ class MediaPlayer():
                                 f'{self.client.sync_attempts}'
                             )
                     continue
-                else:
-                    self.client.sync_attempts = 0
                 client_time = self.get_current_time()
                 if DEBUG:
                     print(


### PR DESCRIPTION
Resolves #147

Add GitHub Actions to run the Python tests on code pushes.

### Acceptance Criteria
- [x] Add Github Actions to run Python tests

### Relevant design files
* None

### Testing instructions
1. See that the GitHub Action runs and passes: https://github.com/ACMILabs/media-player/actions

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- ~[ ] New logic has been documented~
- ~[ ] New logic has appropriate unit tests~
- ~[ ] Changelog has been updated if necessary~
- ~[ ] Deployment / migration instruction have been updated if required~
