### PR TITLE
#146 Fix Glenn's media wall blank screens

### DIFF
--- a/scripts/pi.sh
+++ b/scripts/pi.sh
@@ -67,8 +67,8 @@ else
   echo "Screen resolution parsed as: ${SCREEN_WIDTH}x${SCREEN_HEIGHT}"
 fi
 
-# If DISPLAY isn't set, restart the mediaplayer container
-if [[ ! -z "$DISPLAY" ]]; then
+# If DISPLAY still isn't set, restart the mediaplayer container
+if [[ -z "$DISPLAY" ]]; then
   echo "ERROR: DISPLAY isn't set, so restarting the media player container: ${DISPLAY}"
   curl -H "Content-Type: application/json" -d "{\"serviceName\": \"$BALENA_SERVICE_NAME\"}" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/restart-service?apikey=$BALENA_SUPERVISOR_API_KEY"
 fi

--- a/scripts/pi.sh
+++ b/scripts/pi.sh
@@ -67,6 +67,12 @@ else
   echo "Screen resolution parsed as: ${SCREEN_WIDTH}x${SCREEN_HEIGHT}"
 fi
 
+# If DISPLAY isn't set, restart the mediaplayer container
+if [[ ! -z "$DISPLAY" ]]; then
+  echo "ERROR: DISPLAY isn't set, so restarting the media player container: ${DISPLAY}"
+  curl -H "Content-Type: application/json" -d "{\"serviceName\": \"$BALENA_SERVICE_NAME\"}" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/restart-service?apikey=$BALENA_SUPERVISOR_API_KEY"
+fi
+
 # Unmute system audio
 # ./scripts/unmute.sh
 


### PR DESCRIPTION
Resolves #146

Check DISPLAY is set before starting media-player.py and restartt container if not.

### Acceptance Criteria
- [x] Before starting `media-player.py` check that the env var `DISPLAY` is set, if not restart the `mediaplayer` container

### Relevant design files
* None

### Testing instructions
1. Reboot all `FSF-04` media players (when there aren't any tours on)
2. See that none of the screens are blank, and none output the error: `Can't open display :0` or `Screen resolution parsed as: x`

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- ~[ ] New logic has been documented~
- ~[ ] New logic has appropriate unit tests~
- ~[ ] Changelog has been updated if necessary~
- ~[ ] Deployment / migration instruction have been updated if required~
