### PR TITLE
#146 Attempt 2 at restarting media wall players who can't detect their display

### DIFF
--- a/scripts/pi.sh
+++ b/scripts/pi.sh
@@ -67,9 +67,9 @@ else
   echo "Screen resolution parsed as: ${SCREEN_WIDTH}x${SCREEN_HEIGHT}"
 fi
 
-# If DISPLAY still isn't set, restart the mediaplayer container
-if [[ -z "$DISPLAY" ]]; then
-  echo "ERROR: DISPLAY isn't set, so restarting the media player container: ${DISPLAY}"
+# If DISPLAY, SCREEN_WIDTH or SCREEN_HEIGHT still isn't set, restart the mediaplayer container
+if [[ -z "$DISPLAY" ]] || [[ -z "$SCREEN_WIDTH" ]] || [[ -z "$SCREEN_HEIGHT" ]]; then
+  echo "ERROR: DISPLAY, SCREEN_WIDTH or SCREEN_HEIGHT isn't set, so restarting the media player container: ${DISPLAY}, ${SCREEN_WIDTH}x${SCREEN_HEIGHT}"
   curl -H "Content-Type: application/json" -d "{\"serviceName\": \"$BALENA_SERVICE_NAME\"}" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/restart-service?apikey=$BALENA_SUPERVISOR_API_KEY"
 fi
 


### PR DESCRIPTION
Resolves #146

Also check SCREEN_WIDTH and SCREEN_HEIGHT variables are set, as the error message suggests that DISPLAY is set, but the screen dimensions are not.

### Acceptance Criteria
- [x] Before starting `media-player.py` check that the env var `DISPLAY`, `SCREEN_WIDTH` and `SCREEN_HEIGHT` is set, if not restart the `mediaplayer` container

### Relevant design files
* None

### Testing instructions
1. Get Glenn to reboot the media wall
2. See that any that have bad display connections restart their containers and then run okay

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- ~[ ] New logic has been documented~
- ~[ ] New logic has appropriate unit tests~
- ~[ ] Changelog has been updated if necessary~
- ~[ ] Deployment / migration instruction have been updated if required~
