### PR TITLE
#159 Restart the mediaplayer container in a loop to avoid supervisor connection failures

### DIFF
--- a/scripts/pi.sh
+++ b/scripts/pi.sh
@@ -69,8 +69,13 @@ fi
 
 # If DISPLAY, SCREEN_WIDTH or SCREEN_HEIGHT still isn't set, restart the mediaplayer container
 if [[ -z "$DISPLAY" ]] || [[ -z "$SCREEN_WIDTH" ]] || [[ -z "$SCREEN_HEIGHT" ]]; then
-  echo "ERROR: DISPLAY, SCREEN_WIDTH or SCREEN_HEIGHT isn't set, so restarting the media player container: ${DISPLAY}, ${SCREEN_WIDTH}x${SCREEN_HEIGHT}"
-  curl -H "Content-Type: application/json" -d "{\"serviceName\": \"$BALENA_SERVICE_NAME\"}" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/restart-service?apikey=$BALENA_SUPERVISOR_API_KEY"
+  echo "ERROR: DISPLAY, SCREEN_WIDTH or SCREEN_HEIGHT isn't set, so restarting the mediaplayer container: ${DISPLAY}, ${SCREEN_WIDTH}x${SCREEN_HEIGHT}"
+  for i in {1..10}
+  do
+    echo "Attempt ${i} to restart mediaplayer..."
+    curl -H "Content-Type: application/json" -d "{\"serviceName\": \"$BALENA_SERVICE_NAME\"}" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/restart-service?apikey=$BALENA_SUPERVISOR_API_KEY"
+    sleep 5
+  done
 fi
 
 # Unmute system audio


### PR DESCRIPTION
Resolves #159

[Balena forums](https://forums.balena.io/t/failed-to-connect-to-supervisor-api/22610) note that sometimes the supervisor might be down, so try restarting in a loop.

### Acceptance Criteria
- [x] The `mediaplayer` container is failing to connect to the supervisor to restart itself the first time, so try in a 10x loop with a pause between attempts

### Relevant design files
* None

### Testing instructions
1. See that your dev media player starts okay: https://dashboard.balena-cloud.com/apps/1505457/devices
1. Restart all `FSF-04-` media players and see that when a media player needs to restart its container, that it happens. [FSF-04-AV01-RP60](https://dashboard.balena-cloud.com/devices/fc8805583db693678a4a92a268e0b5cf/summary) is a good example.

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- ~[ ] New logic has been documented~
- ~[ ] New logic has appropriate unit tests~
- ~[ ] Changelog has been updated if necessary~
- ~[ ] Deployment / migration instruction have been updated if required~
