### PR TITLE
#164 Add 30 seconds sleep before restarting mediaplayer

### DIFF
--- a/scripts/pi.sh
+++ b/scripts/pi.sh
@@ -72,9 +72,10 @@ if [[ -z "$DISPLAY" ]] || [[ -z "$SCREEN_WIDTH" ]] || [[ -z "$SCREEN_HEIGHT" ]];
   echo "ERROR: DISPLAY, SCREEN_WIDTH or SCREEN_HEIGHT isn't set, so restarting the mediaplayer container: ${DISPLAY}, ${SCREEN_WIDTH}x${SCREEN_HEIGHT}"
   for i in {1..10}
   do
-    echo "Attempt ${i} to restart mediaplayer..."
+    echo "Attempt ${i} to restart mediaplayer in 30 seconds..."
+    sleep 30
     curl -H "Content-Type: application/json" -d "{\"serviceName\": \"$BALENA_SERVICE_NAME\"}" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/restart-service?apikey=$BALENA_SUPERVISOR_API_KEY"
-    sleep 5
+    sleep 30
   done
 fi
 


### PR DESCRIPTION
Resolves #164

Increase the `sleep` time between container restarts to see if that helps Balena avoid failing to restart `mediaplayer`

### Acceptance Criteria
- [x] Increase the `sleep` time between container restarts to see if that helps Balena avoid failing to restart `mediaplayer`

### Relevant design files
* None

### Testing instructions
1. None

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- ~[ ] New logic has been documented~
- ~[ ] New logic has appropriate unit tests~
- ~[ ] Changelog has been updated if necessary~
- ~[ ] Deployment / migration instruction have been updated if required~
