### PR TITLE
#166 For analog headphones audio, unmute Master audio

### DIFF
--- a/scripts/x86.sh
+++ b/scripts/x86.sh
@@ -77,7 +77,12 @@ elif [[ ! -z "$SCREEN_WIDTH" ]] && [[ ! -z "$SCREEN_HEIGHT" ]]; then
   xrandr -s "$SCREEN_WIDTH"x"$SCREEN_HEIGHT"
 fi
 
-# Unmute system audio
-# ./scripts/unmute.sh
+# If headphones audio is selected, we need to unmute Master audio
+if [[ ! -z "$AUDIO_DEVICE_REGEX" ]] && [[ $AUDIO_DEVICE_REGEX == "headphones" ]]; then
+  echo "Headphones selected, so un-muting master audio..."
+  ./scripts/unmute.sh
+  echo "Setting AUDIO_DEVICE_REGEX to 'analog' for Optiplex 3070..."
+  export AUDIO_DEVICE_REGEX=analog
+fi
 
 python media_player.py


### PR DESCRIPTION
Resolves #166

Selecting `Headphones` in XOS doesn't output audio on Dell Optiplexes. This resolves it by unmuting Master audio and selecting the correct sound card.

### Acceptance Criteria
- [x] Unmute system `Master` audio if `$AUDIO_DEVICE_REGEX == "headphones"`
- [x] Set `AUDIO_DEVICE_REGEX` to `analog` to match Dell Optiplex 3070 analog audio card

### Relevant design files
* None

### Testing instructions
1. Reboot [DD-00-AV10A-PC01](https://dashboard.balena-cloud.com/devices/b7c1c2917c84b9af70b934abb3572da4/summary) and note that audio comes out of the headphones
2. Set AUDIO_DEVICE_REGEX env var to `mute` and note that the audio is muted

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- ~[ ] New logic has been documented~
- ~[ ] New logic has appropriate unit tests~
- ~[ ] Changelog has been updated if necessary~
- ~[ ] Deployment / migration instruction have been updated if required~
