### PR TITLE
#153 Only try and sync if the target time is less than the video length

### DIFF
--- a/media_player.py
+++ b/media_player.py
@@ -576,7 +576,16 @@ class MediaPlayer():  # pylint: disable=too-many-branches
                             f'Drifted, syncing with server: {server_time} '
                             f'plus sync latency of {SYNC_LATENCY}'
                         )
-                    self.vlc['player'].set_time(server_time + int(SYNC_LATENCY))
+                    target_time = server_time + int(SYNC_LATENCY)
+                    video_length = self.vlc['player'].get_length()
+                    if target_time > video_length:
+                        if DEBUG:
+                            print(
+                                f'Target time {target_time} is greater than the length '
+                                f'of this video: {video_length}, ignoring sync...'
+                            )
+                    else:
+                        self.vlc['player'].set_time(target_time)
 
         if SYNC_IS_SERVER:
             while True:

--- a/tests/playback_sync_tests.py
+++ b/tests/playback_sync_tests.py
@@ -118,6 +118,7 @@ def test_client_drifts_from_server():
     player = MediaPlayer()
     player.client.receive = MagicMock(return_value=50)
     player.get_current_time = MagicMock(return_value=100)
+    player.vlc['player'].get_length = MagicMock(return_value=3000)
     assert_called_in_infinite_loop(
         'vlc.MediaPlayer.set_time',
         player.sync_to_server


### PR DESCRIPTION
Resolves #153

Fix media player syncing for Raspberry Pis by only trying to sync if the target time is less than the video length.

### Acceptance Criteria
- [x] Only try and sync if the target time is less than the video length

### Relevant design files
* None

### Testing instructions
1. Break the download of a video on a media player client
2. Set it up to sync, and note that it doesn't skip if it can't sync

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- ~[ ] New logic has been documented~
- ~[ ] New logic has appropriate unit tests~
- ~[ ] Changelog has been updated if necessary~
- ~[ ] Deployment / migration instruction have been updated if required~
