### PR TITLE
#173 Add SYNC_MAX_CLIENTS as an environment variable so that it can be set by XOS

### DIFF
--- a/network.py
+++ b/network.py
@@ -2,9 +2,12 @@
 Based on: https://github.com/oaubert/python-vlc/tree/master/examples/video_sync
 """
 
+import os
 import socket
 import threading
 import time
+
+SYNC_MAX_CLIENTS = int(os.getenv('SYNC_MAX_CLIENTS', '5'))
 
 
 class Server:
@@ -20,7 +23,7 @@ class Server:
         self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self.sock.bind((host, port))
 
-        self.sock.listen(5)
+        self.sock.listen(SYNC_MAX_CLIENTS)
 
         self.clients = set()
         listener_thread = threading.Thread(target=self.listen_for_clients, args=())


### PR DESCRIPTION
Resolves #173

Add `SYNC_MAX_CLIENTS` as an environment variable, so we can set more than 5 media players to sync, and we can also set it in XOS.

### Acceptance Criteria
- [x] Set `SYNC_MAX_CLIENTS` as an environment variable defaulting to `5`

### Relevant design files
* None

### Testing instructions
1. Add `SYNC_MAX_CLIENTS` to a synced media player server, set it to a value and see that that number of clients can still connect to it. Try in [s__media-player-pi-4](https://dashboard.balena-cloud.com/apps/1505457/devices)

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- ~[ ] New logic has been documented~
- ~[ ] New logic has appropriate unit tests~
- ~[ ] Changelog has been updated if necessary~
- ~[ ] Deployment / migration instruction have been updated if required~
