### PR TITLE
#172 Add video length to the debug logging to help debug sync issues

### DIFF
--- a/media_player.py
+++ b/media_player.py
@@ -571,13 +571,14 @@ class MediaPlayer():  # pylint: disable=too-many-branches
                         f'drift: {abs(client_time - server_time)}'
                     )
                 if abs(client_time - server_time) > int(SYNC_DRIFT_THRESHOLD):
+                    target_time = server_time + int(SYNC_LATENCY)
+                    video_length = int(self.vlc['player'].get_length())
                     if DEBUG:
                         print(
                             f'Drifted, syncing with server: {server_time} '
-                            f'plus sync latency of {SYNC_LATENCY}'
+                            f'plus sync latency of {SYNC_LATENCY}. '
+                            f'Target: {target_time}, video length: {video_length}'
                         )
-                    target_time = server_time + int(SYNC_LATENCY)
-                    video_length = self.vlc['player'].get_length()
                     if target_time > video_length:
                         if DEBUG:
                             print(


### PR DESCRIPTION
Resolves #172

Add video length to the debug logging to help debug sync issues.

### Acceptance Criteria
- [x] Add `video_length` to the debug output for sync drift

### Relevant design files
* None

### Testing instructions
1. See the video length on [Sam's media player](https://dashboard.balena-cloud.com/devices/a5a3874a3e61f14224e9baaa6290b3bd/summary)

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- ~[ ] New logic has been documented~
- ~[ ] New logic has appropriate unit tests~
- ~[ ] Changelog has been updated if necessary~
- ~[ ] Deployment / migration instruction have been updated if required~
