### PR TITLE
#156 Add current playlist position to sync messages

### DIFF
--- a/media_player.py
+++ b/media_player.py
@@ -634,7 +634,7 @@ class MediaPlayer():  # pylint: disable=too-many-branches
             while True:
                 time.sleep(1)
                 current_playlist_position = (
-                    self.get_current_playlist_position or self.current_playlist_position
+                    self.get_current_playlist_position() or self.current_playlist_position
                 )
                 self.server.send(f'{current_playlist_position},{self.get_current_time()}')
                 self.print_debug(f'Clients: {self.server.clients}')

--- a/media_player.py
+++ b/media_player.py
@@ -575,10 +575,11 @@ class MediaPlayer():  # pylint: disable=too-many-branches
                             )
                     continue
                 client_time = self.get_current_time()
+                client_playlist_position = self.current_playlist_position
                 if DEBUG:
                     print(
                         f'Server playlist/time: {server_playlist_position}/{server_time}, '
-                        f'client playlist/time: {self.current_playlist_position}/{client_time}, '
+                        f'client playlist/time: {client_playlist_position}/{client_time}, '
                         f'drift: {abs(client_time - server_time)}'
                     )
                 if abs(client_time - server_time) > int(SYNC_DRIFT_THRESHOLD):
@@ -597,11 +598,11 @@ class MediaPlayer():  # pylint: disable=too-many-branches
                                 f'of this video: {video_length}, ignoring sync...'
                             )
                     else:
-                        if not self.current_playlist_position == server_playlist_position:
+                        if not client_playlist_position == server_playlist_position:
                             if DEBUG:
                                 print(
                                     f'Server playlist {server_playlist_position} is different to '
-                                    f'client {self.current_playlist_position}, syncing now...'
+                                    f'client {client_playlist_position}, syncing now...'
                                 )
                             self.vlc['list_player'].play_item_at_index(server_playlist_position)
 

--- a/media_player.py
+++ b/media_player.py
@@ -118,9 +118,8 @@ class MediaPlayer():  # pylint: disable=too-many-branches
         flags.append('--freetype-background-opacity=255')
         flags.append('--freetype-background-color=0')
         if SCREEN_WIDTH and SCREEN_HEIGHT:
-            if DEBUG:
-                print(f'Attempting to set media player screen '
-                      f'resolution to: {SCREEN_WIDTH}x{SCREEN_HEIGHT}')
+            self.print_debug(f'Attempting to set media player screen '
+                             f'resolution to: {SCREEN_WIDTH}x{SCREEN_HEIGHT}')
             flags.append(f'--width={SCREEN_WIDTH}')
             flags.append(f'--height={SCREEN_HEIGHT}')
         self.vlc['instance'] = vlc.Instance(flags)
@@ -140,6 +139,14 @@ class MediaPlayer():  # pylint: disable=too-many-branches
 
         if SYNC_CLIENT_TO:
             self.client = network.Client(SYNC_CLIENT_TO, port=10000)
+
+    @staticmethod
+    def print_debug(message):
+        """
+        Print debug output if DEBUG is set true.
+        """
+        if DEBUG:
+            print(message)
 
     @staticmethod
     def datetime_now():
@@ -562,48 +569,41 @@ class MediaPlayer():  # pylint: disable=too-many-branches
                 else:
                     self.client.sync_attempts += 1
                     if self.client.sync_attempts > 3:
-                        if DEBUG:
-                            print('No server_time received, attempting to re-setup sync...')
+                        self.print_debug('No server_time received, attempting to re-setup sync...')
                         self.setup_sync()
-                        if DEBUG:
-                            print(f'Sync attempts reset to: {self.client.sync_attempts}')
+                        self.print_debug(f'Sync attempts reset to: {self.client.sync_attempts}')
                     else:
-                        if DEBUG:
-                            print(
-                                'No server_time received, sync_attempts: '
-                                f'{self.client.sync_attempts}'
-                            )
+                        self.print_debug(
+                            'No server_time received, sync_attempts: '
+                            f'{self.client.sync_attempts}'
+                        )
                     continue
                 client_time = self.get_current_time()
                 client_playlist_position = self.current_playlist_position
-                if DEBUG:
-                    print(
-                        f'Server playlist/time: {server_playlist_position}/{server_time}, '
-                        f'client playlist/time: {client_playlist_position}/{client_time}, '
-                        f'drift: {abs(client_time - server_time)}'
-                    )
+                self.print_debug(
+                    f'Server playlist/time: {server_playlist_position}/{server_time}, '
+                    f'client playlist/time: {client_playlist_position}/{client_time}, '
+                    f'drift: {abs(client_time - server_time)}'
+                )
                 if abs(client_time - server_time) > int(SYNC_DRIFT_THRESHOLD):
                     target_time = server_time + int(SYNC_LATENCY)
                     video_length = int(self.vlc['player'].get_length())
-                    if DEBUG:
-                        print(
-                            f'Drifted, syncing with server: {server_time} '
-                            f'plus sync latency of {SYNC_LATENCY}. '
-                            f'Target: {target_time}, video length: {video_length}'
-                        )
+                    self.print_debug(
+                        f'Drifted, syncing with server: {server_time} '
+                        f'plus sync latency of {SYNC_LATENCY}. '
+                        f'Target: {target_time}, video length: {video_length}'
+                    )
                     if target_time > video_length:
-                        if DEBUG:
-                            print(
-                                f'Target time {target_time} is greater than the length '
-                                f'of this video: {video_length}, ignoring sync...'
-                            )
+                        self.print_debug(
+                            f'Target time {target_time} is greater than the length '
+                            f'of this video: {video_length}, ignoring sync...'
+                        )
                     else:
                         if not client_playlist_position == server_playlist_position:
-                            if DEBUG:
-                                print(
-                                    f'Server playlist {server_playlist_position} is different to '
-                                    f'client {client_playlist_position}, syncing now...'
-                                )
+                            self.print_debug(
+                                f'Server playlist {server_playlist_position} is different to '
+                                f'client {client_playlist_position}, syncing now...'
+                            )
                             self.vlc['list_player'].play_item_at_index(server_playlist_position)
 
                         self.vlc['player'].set_time(target_time)
@@ -612,8 +612,7 @@ class MediaPlayer():  # pylint: disable=too-many-branches
             while True:
                 time.sleep(1)
                 self.server.send(f'{self.current_playlist_position},{self.get_current_time()}')
-                if DEBUG:
-                    print(f'Clients: {self.server.clients}')
+                self.print_debug(f'Clients: {self.server.clients}')
 
 
 if __name__ == "__main__":

--- a/media_player.py
+++ b/media_player.py
@@ -41,7 +41,7 @@ SYNC_CLIENT_TO = os.getenv('SYNC_CLIENT_TO')
 SYNC_IS_SERVER = os.getenv('SYNC_IS_SERVER', 'false') == 'true'
 SYNC_DRIFT_THRESHOLD = os.getenv('SYNC_DRIFT_THRESHOLD', '40')  # threshold in milliseconds
 SYNC_LATENCY = os.getenv('SYNC_LATENCY', '30')  # latency to sync a client in milliseconds
-SYNC_IGNORE_THRESHOLD = os.getenv('SYNC_DRIFT_THRESHOLD', '2000')  # threshold in milliseconds
+SYNC_IGNORE_THRESHOLD = os.getenv('SYNC_IGNORE_THRESHOLD', '2000')  # threshold in milliseconds
 IS_SYNCED_PLAYER = SYNC_CLIENT_TO or SYNC_IS_SERVER
 DEBUG = os.getenv('DEBUG', 'false') == 'true'
 SCREEN_WIDTH = os.getenv('SCREEN_WIDTH')
@@ -616,6 +616,7 @@ class MediaPlayer():  # pylint: disable=too-many-branches
                     )
 
                 if abs(client_time - server_time) > int(SYNC_DRIFT_THRESHOLD):
+                    sync = True
                     target_time = server_time + int(SYNC_LATENCY)
                     video_length = int(self.vlc['player'].get_length())
                     video_time_remaining = video_length - target_time
@@ -624,17 +625,19 @@ class MediaPlayer():  # pylint: disable=too-many-branches
                         f'plus sync latency of {SYNC_LATENCY}. '
                         f'Target: {target_time}, video length: {video_length}'
                     )
-                    if target_time > video_length:
-                        self.print_debug(
-                            f'Target time {target_time} is greater than the length '
-                            f'of this video: {video_length}, ignoring sync...'
-                        )
-                    elif video_time_remaining < int(SYNC_IGNORE_THRESHOLD):
+                    if video_time_remaining < int(SYNC_IGNORE_THRESHOLD):
+                        sync = False
                         self.print_debug(
                             f'Only {video_time_remaining}/{video_length} remaining, '
                             f'(threashold {SYNC_IGNORE_THRESHOLD}) so ignoring sync...'
                         )
-                    else:
+                    if target_time > video_length:
+                        sync = False
+                        self.print_debug(
+                            f'Target time {target_time} is greater than the length '
+                            f'of this video: {video_length}, ignoring sync...'
+                        )
+                    if sync:
                         self.vlc['player'].set_time(target_time)
 
         if SYNC_IS_SERVER:

--- a/media_player.py
+++ b/media_player.py
@@ -594,6 +594,10 @@ class MediaPlayer():  # pylint: disable=too-many-branches
                     continue
 
                 client_time = self.get_current_time()
+                if server_time == 0 or client_time == 0:
+                    # Avoid syncing at the beginning of videos
+                    continue
+
                 client_playlist_position = (
                     self.get_current_playlist_position() or self.current_playlist_position
                 )
@@ -619,6 +623,9 @@ class MediaPlayer():  # pylint: disable=too-many-branches
                     sync = True
                     target_time = server_time + int(SYNC_LATENCY)
                     video_length = int(self.vlc['player'].get_length())
+                    if video_length == 0:
+                        # Avoid syncing when the video length is zero
+                        continue
                     video_time_remaining = video_length - target_time
                     self.print_debug(
                         f'Drifted, syncing with server: {server_time} '

--- a/media_player.py
+++ b/media_player.py
@@ -599,7 +599,7 @@ class MediaPlayer():  # pylint: disable=too-many-branches
                             f'of this video: {video_length}, ignoring sync...'
                         )
                     else:
-                        if not client_playlist_position == server_playlist_position:
+                        if client_playlist_position != server_playlist_position:
                             self.print_debug(
                                 f'Server playlist {server_playlist_position} is different to '
                                 f'client {client_playlist_position}, syncing now...'

--- a/media_player.py
+++ b/media_player.py
@@ -41,6 +41,7 @@ SYNC_CLIENT_TO = os.getenv('SYNC_CLIENT_TO')
 SYNC_IS_SERVER = os.getenv('SYNC_IS_SERVER', 'false') == 'true'
 SYNC_DRIFT_THRESHOLD = os.getenv('SYNC_DRIFT_THRESHOLD', '40')  # threshold in milliseconds
 SYNC_LATENCY = os.getenv('SYNC_LATENCY', '30')  # latency to sync a client in milliseconds
+SYNC_IGNORE_THRESHOLD = os.getenv('SYNC_DRIFT_THRESHOLD', '2000')  # threshold in milliseconds
 IS_SYNCED_PLAYER = SYNC_CLIENT_TO or SYNC_IS_SERVER
 DEBUG = os.getenv('DEBUG', 'false') == 'true'
 SCREEN_WIDTH = os.getenv('SCREEN_WIDTH')
@@ -617,6 +618,7 @@ class MediaPlayer():  # pylint: disable=too-many-branches
                 if abs(client_time - server_time) > int(SYNC_DRIFT_THRESHOLD):
                     target_time = server_time + int(SYNC_LATENCY)
                     video_length = int(self.vlc['player'].get_length())
+                    video_time_remaining = video_length - target_time
                     self.print_debug(
                         f'Drifted, syncing with server: {server_time} '
                         f'plus sync latency of {SYNC_LATENCY}. '
@@ -626,6 +628,11 @@ class MediaPlayer():  # pylint: disable=too-many-branches
                         self.print_debug(
                             f'Target time {target_time} is greater than the length '
                             f'of this video: {video_length}, ignoring sync...'
+                        )
+                    elif video_time_remaining < int(SYNC_IGNORE_THRESHOLD):
+                        self.print_debug(
+                            f'Only {video_time_remaining}/{video_length} remaining, '
+                            f'(threashold {SYNC_IGNORE_THRESHOLD}) so ignoring sync...'
                         )
                     else:
                         self.vlc['player'].set_time(target_time)

--- a/media_player.py
+++ b/media_player.py
@@ -578,6 +578,7 @@ class MediaPlayer():  # pylint: disable=too-many-branches
                             f'{self.client.sync_attempts}'
                         )
                     continue
+
                 client_time = self.get_current_time()
                 client_playlist_position = self.current_playlist_position
                 self.print_debug(
@@ -585,6 +586,19 @@ class MediaPlayer():  # pylint: disable=too-many-branches
                     f'client playlist/time: {client_playlist_position}/{client_time}, '
                     f'drift: {abs(client_time - server_time)}'
                 )
+
+                if client_playlist_position != server_playlist_position:
+                    self.print_debug(
+                        f'Server playlist {server_playlist_position} is different to '
+                        f'client {client_playlist_position}, syncing now...'
+                    )
+                    self.vlc['list_player'].play_item_at_index(server_playlist_position)
+                    client_time = self.get_current_time()
+                    client_playlist_position = server_playlist_position
+                    self.print_debug(
+                        f'Client now at: {client_playlist_position}/{client_time}'
+                    )
+
                 if abs(client_time - server_time) > int(SYNC_DRIFT_THRESHOLD):
                     target_time = server_time + int(SYNC_LATENCY)
                     video_length = int(self.vlc['player'].get_length())
@@ -599,13 +613,6 @@ class MediaPlayer():  # pylint: disable=too-many-branches
                             f'of this video: {video_length}, ignoring sync...'
                         )
                     else:
-                        if client_playlist_position != server_playlist_position:
-                            self.print_debug(
-                                f'Server playlist {server_playlist_position} is different to '
-                                f'client {client_playlist_position}, syncing now...'
-                            )
-                            self.vlc['list_player'].play_item_at_index(server_playlist_position)
-
                         self.vlc['player'].set_time(target_time)
 
         if SYNC_IS_SERVER:

--- a/media_player.py
+++ b/media_player.py
@@ -561,8 +561,8 @@ class MediaPlayer():  # pylint: disable=too-many-branches
                 try:
                     server_playlist_position = server_state[0]
                     server_time = server_state[1]
-                except IndexError as exception:
-                    print(f'Error from server_state data: {server_state}, exception: {exception}')
+                except (IndexError, TypeError) as exception:
+                    print(f'Unexpected server_state data: {server_state}, exception: {exception}')
                     continue
                 if server_time:
                     self.client.sync_attempts = 0

--- a/media_player.py
+++ b/media_player.py
@@ -444,6 +444,7 @@ class MediaPlayer():  # pylint: disable=too-many-branches
                 sentry_sdk.capture_exception(exception)
         message = f'Tried to download {url} {DOWNLOAD_RETRIES} times, giving up.'
         print(message)
+        return None
 
     def download_playlist_from_xos(self):
         """

--- a/network.py
+++ b/network.py
@@ -76,15 +76,17 @@ class Client:  # pylint: disable=R0903
 
     def receive(self):
         """
-        Receives data and tries to parse it into an integer containing
-        the time of the server player in milliseconds.
+        Receives data and tries to parse it into a list of integers containing
+        the current playlist position, and time of the server player in milliseconds.
         """
         try:
             data = self.sock.recv(4096)
             if data:
                 data = data.decode()
-                pos = data.split(',')[-2]
-                return int(pos)
+                comma_separated_server_state_string = data.split(',')[-2]  # playlist_position,time
+                server_state_strings = comma_separated_server_state_string.split(',')
+                server_state_ints = list(map(int, server_state_strings))
+                return server_state_ints
             print(f'No data received... {data}')
             return None
         except OSError:

--- a/network.py
+++ b/network.py
@@ -82,11 +82,8 @@ class Client:  # pylint: disable=R0903
         try:
             data = self.sock.recv(4096)
             if data:
-                data = data.decode()
-                # playlist_position,time
-                server_state_strings = [data.split(',')[-3], data.split(',')[-2]]
-                server_state_ints = list(map(int, server_state_strings))
-                return server_state_ints
+                data = data.decode().split(',')
+                return [int(data[-3]), int(data[-2])]
             print(f'No data received... {data}')
             return None
         except OSError:

--- a/network.py
+++ b/network.py
@@ -86,8 +86,8 @@ class Client:  # pylint: disable=R0903
                 return [int(data[-3]), int(data[-2])]
             print(f'No data received... {data}')
             return None
-        except OSError:
-            print(f'Closing socket: {self.sock}')
+        except (OSError, ValueError) as exception:
+            print(f'Closing socket: {self.sock} becuase of error: {exception}')
             self.sock.close()
             print('Attempting to reconnect...')
             self.connect()

--- a/network.py
+++ b/network.py
@@ -86,8 +86,8 @@ class Client:  # pylint: disable=R0903
                 return [int(data[-3]), int(data[-2])]
             print(f'No data received... {data}')
             return None
-        except (OSError, ValueError) as exception:
-            print(f'Closing socket: {self.sock} becuase of error: {exception}')
+        except OSError:
+            print(f'Closing socket: {self.sock}')
             self.sock.close()
             print('Attempting to reconnect...')
             self.connect()

--- a/network.py
+++ b/network.py
@@ -83,8 +83,8 @@ class Client:  # pylint: disable=R0903
             data = self.sock.recv(4096)
             if data:
                 data = data.decode()
-                comma_separated_server_state_string = data.split(',')[-2]  # playlist_position,time
-                server_state_strings = comma_separated_server_state_string.split(',')
+                # playlist_position,time
+                server_state_strings = [data.split(',')[-3], data.split(',')[-2]]
                 server_state_ints = list(map(int, server_state_strings))
                 return server_state_ints
             print(f'No data received... {data}')

--- a/tests/playback_sync_tests.py
+++ b/tests/playback_sync_tests.py
@@ -151,3 +151,22 @@ def test_client_drifts_from_server_sets_playlist_position():
         'vlc.MediaListPlayer.play_item_at_index',
         player.sync_to_server
     )
+
+
+@patch('media_player.network.Client', MagicMock())
+@patch('media_player.SYNC_CLIENT_TO', '100.100.100.100')
+@patch('media_player.IS_SYNCED_PLAYER', True)
+def test_client_playlist_position_set_without_drift():
+    """
+    Check that a client's playlist position is set even if
+    the client hasn't drifted from the server.
+    """
+    player = MediaPlayer()
+    player.client.receive = MagicMock(return_value=[2, 95])
+    player.get_current_time = MagicMock(return_value=100)
+    player.current_playlist_position = 1
+    player.vlc['player'].get_length = MagicMock(return_value=3000)
+    assert_called_in_infinite_loop(
+        'vlc.MediaListPlayer.play_item_at_index',
+        player.sync_to_server
+    )

--- a/tests/playback_sync_tests.py
+++ b/tests/playback_sync_tests.py
@@ -134,6 +134,15 @@ def test_client_drifts_from_server():
             player.sync_to_server
         )
 
+    # Assert sync isn't called within 2 seconds of the end of the current video
+    with pytest.raises(AssertionError):
+        player.client.receive = MagicMock(return_value=[1, 2500])
+        player.get_current_time = MagicMock(return_value=2000)
+        assert_called_in_infinite_loop(
+            'vlc.MediaPlayer.set_time',
+            player.sync_to_server
+        )
+
 
 @patch('media_player.network.Client', MagicMock())
 @patch('media_player.SYNC_CLIENT_TO', '100.100.100.100')

--- a/tests/playback_sync_tests.py
+++ b/tests/playback_sync_tests.py
@@ -90,10 +90,18 @@ def test_server_sends_time_to_client():
     Check that the server sends data to the clients.
     """
     player = MediaPlayer()
+    player.get_current_playlist_position = MagicMock(return_value=1)
     assert_called_in_infinite_loop(
         'media_player.MediaPlayer.get_current_time',
         player.sync_to_server
     )
+
+    with pytest.raises(AssertionError):
+        player.get_current_playlist_position = MagicMock(return_value=None)
+        assert_called_in_infinite_loop(
+            'media_player.MediaPlayer.get_current_time',
+            player.sync_to_server
+        )
 
 
 @patch('media_player.network.Client', MagicMock())
@@ -120,8 +128,7 @@ def test_client_drifts_from_server():
     player = MediaPlayer()
     player.client.receive = MagicMock(return_value=[1, 50])
     player.get_current_time = MagicMock(return_value=100)
-    player.current_playlist_position = 1
-    player.get_current_playlist_position = MagicMock(return_value=None)
+    player.get_current_playlist_position = MagicMock(return_value=1)
     player.vlc['player'].get_length = MagicMock(return_value=3000)
     assert_called_in_infinite_loop(
         'vlc.MediaPlayer.set_time',
@@ -155,8 +162,7 @@ def test_client_drifts_from_server_sets_playlist_position():
     player = MediaPlayer()
     player.client.receive = MagicMock(return_value=[2, 50])
     player.get_current_time = MagicMock(return_value=100)
-    player.current_playlist_position = 1
-    player.get_current_playlist_position = MagicMock(return_value=None)
+    player.get_current_playlist_position = MagicMock(return_value=1)
     player.vlc['player'].get_length = MagicMock(return_value=3000)
     assert_called_in_infinite_loop(
         'vlc.MediaListPlayer.play_item_at_index',
@@ -175,17 +181,8 @@ def test_client_playlist_position_set_without_drift():
     player = MediaPlayer()
     player.client.receive = MagicMock(return_value=[2, 95])
     player.get_current_time = MagicMock(return_value=100)
-    player.current_playlist_position = 1
-    player.get_current_playlist_position = MagicMock(return_value=None)
-    player.vlc['player'].get_length = MagicMock(return_value=3000)
-    assert_called_in_infinite_loop(
-        'vlc.MediaListPlayer.play_item_at_index',
-        player.sync_to_server
-    )
-
-    # If get_current_playback_position() returns a value, it uses that
-    player.current_playlist_position = 2
     player.get_current_playlist_position = MagicMock(return_value=1)
+    player.vlc['player'].get_length = MagicMock(return_value=3000)
     assert_called_in_infinite_loop(
         'vlc.MediaListPlayer.play_item_at_index',
         player.sync_to_server
@@ -193,7 +190,6 @@ def test_client_playlist_position_set_without_drift():
 
     with pytest.raises(AssertionError):
         # Assert playlist sync isn't called
-        player.current_playlist_position = 2
         player.get_current_playlist_position = MagicMock(return_value=2)
         assert_called_in_infinite_loop(
             'vlc.MediaListPlayer.play_item_at_index',

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -56,7 +56,8 @@ def test_media_player():
     media_player = MediaPlayer()
     assert media_player.playlist == []
     assert len(media_player.vlc) == 4
-    assert all([vlc_var is not None for vlc_var in media_player.vlc.values()])
+    for vlc_var in media_player.vlc.values():
+        assert vlc_var is not None
 
 
 @patch('requests.get', MagicMock(side_effect=mocked_requests_get))


### PR DESCRIPTION
Resolves #156

Add current playlist position to sync messages so that clients can be sure they're playing the correct playlist item when syncing.

### Acceptance Criteria
- [x] Set `DEBUG` to `true` to see sync output
- [x] Investigate why they're not syncing
- [x] Add `current_playlist_position` to sync messages and set client to the correct playlist item when needed

### Relevant design files
* None

### Testing instructions
1. Setup a local Playlist with 3x 10 second videos in it (✔️manually trimmed with ffmpeg)
2. Setup two Raspberry Pi Media Players to be synced players - (already setup here: https://dashboard.balena-cloud.com/apps/1505457/devices)
3. Try playing them on `main` branch for a while to see if the error case occurs: `git checkout main` and `balena push s__media-player-pi-4`
4. Switch to this branch to see that its solved and all players stay in sync on the correct playlist item: `git checkout `fix/156-synced-playlists` and `balena push s__media-player-pi-4 `

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- [x] New logic has been documented
- [x] New logic has appropriate unit tests
- [ ] Changelog has been updated if necessary
~- [ ] Deployment / migration instruction have been updated if required~
