### PR TITLE
#182 More gracefully recover from an OSError from a synced client

### DIFF
--- a/network.py
+++ b/network.py
@@ -88,7 +88,9 @@ class Client:  # pylint: disable=R0903
             return None
         except OSError:
             print(f'Closing socket: {self.sock}')
+            self.sock.shutdown()
             self.sock.close()
+            self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             print('Attempting to reconnect...')
             self.connect()
             return None

--- a/network.py
+++ b/network.py
@@ -88,7 +88,6 @@ class Client:  # pylint: disable=R0903
             return None
         except OSError:
             print(f'Closing socket: {self.sock}')
-            self.sock.shutdown(socket.SHUT_RD)
             self.sock.close()
             self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             print('Attempting to reconnect...')

--- a/network.py
+++ b/network.py
@@ -88,7 +88,7 @@ class Client:  # pylint: disable=R0903
             return None
         except OSError:
             print(f'Closing socket: {self.sock}')
-            self.sock.shutdown()
+            self.sock.shutdown(socket.SHUT_RD)
             self.sock.close()
             self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             print('Attempting to reconnect...')


### PR DESCRIPTION
Resolves #182

More gracefully recover from an `OSError` from a synced client.

### Acceptance Criteria
- [x] Shutdown, close, and re-set `self.sock` when an `OSError` occurs

### Relevant design files
* None

### Testing instructions
1. Add a server and client to: [s__media-player-pi-4](https://dashboard.balena-cloud.com/apps/1505457/summary)
1. Restart/Reboot/container restart and try and break a client getting the output to: `Can't connect to 172.16.83.0 port 10000 `
1. Previously this would hang and not reconnect. Now it should change to: `Waiting for server at 172.16.83.0 port 10000` when the server comes online again
1. The only failure case I can see now is when the server returns a `server_time` of `0`, which is expected behaviour and the client should recover from that gracefully too

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- [x] New logic has been documented
- [x] New logic has appropriate unit tests
~- [ ] Changelog has been updated if necessary~
~- [ ] Deployment / migration instruction have been updated if required~
