### PR TITLE
#188 Add first boot checker

### DIFF
--- a/Dockerfile.raspberrypi4-64
+++ b/Dockerfile.raspberrypi4-64
@@ -5,7 +5,7 @@ FROM balenalib/raspberrypi3:buster
 
 # use `install_packages` if you need to install dependencies,
 # for instance if you need git, just uncomment the line below.
-RUN install_packages vlc vlc-plugin-* g++ python3-pip python3-setuptools python3-dev build-essential \
+RUN install_packages vlc g++ python3-pip python3-setuptools python3-dev build-essential \
   xserver-xorg-core \
   xinit lxsession desktop-file-utils \
   raspberrypi-ui-mods rpd-icons \

--- a/Dockerfile.raspberrypi4-64
+++ b/Dockerfile.raspberrypi4-64
@@ -5,7 +5,16 @@ FROM balenalib/raspberrypi3:buster
 
 # use `install_packages` if you need to install dependencies,
 # for instance if you need git, just uncomment the line below.
-RUN install_packages vlc g++ python3-pip python3-setuptools python3-dev build-essential \
+RUN install_packages \
+  vlc \
+  vlc-plugin-base \
+  vlc-plugin-qt \
+  vlc-plugin-video-output \
+  g++ \
+  python3-pip \
+  python3-setuptools \
+  python3-dev \
+  build-essential \
   xserver-xorg-core \
   xinit lxsession desktop-file-utils \
   raspberrypi-ui-mods rpd-icons \

--- a/Dockerfile.raspberrypi4-64
+++ b/Dockerfile.raspberrypi4-64
@@ -18,7 +18,11 @@ RUN install_packages vlc g++ python3-pip python3-setuptools python3-dev build-es
   # Remove cursor
   unclutter \
   # Parse JSON for boot count
-  jq
+  jq \
+  # Display drivers to avoid VLC errors
+  mesa-vdpau-drivers \
+  vdpau-va-driver \
+  libvdpau1
 
 # disable lxpolkit popup warning
 RUN mv /usr/bin/lxpolkit /usr/bin/lxpolkit.bak

--- a/Dockerfile.raspberrypi4-64
+++ b/Dockerfile.raspberrypi4-64
@@ -16,7 +16,9 @@ RUN install_packages vlc g++ python3-pip python3-setuptools python3-dev build-es
   # Audio
   alsa-utils \
   # Remove cursor
-  unclutter
+  unclutter \
+  # Parse JSON for boot count
+  jq
 
 # disable lxpolkit popup warning
 RUN mv /usr/bin/lxpolkit /usr/bin/lxpolkit.bak

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -6,7 +6,6 @@ FROM balenalib/%%BALENA_ARCH%%-ubuntu-python:3.8-latest-run
 # for instance if you need git, just uncomment the line below.
 RUN install_packages \
   vlc \
-  vlc-plugin-* \
   g++ \
   xserver-xorg-video-intel \
   xserver-xorg-input-evdev \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -24,7 +24,9 @@ RUN install_packages \
   # Intel GPU drivers for VLC
   i965-va-driver \
   vainfo \
-  vdpau-va-driver
+  vdpau-va-driver \
+  # Parse JSON for boot count
+  jq
 
 # Disable screen from turning it off
 RUN echo "#!/bin/bash" > /etc/X11/xinit/xserverrc \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -24,7 +24,7 @@ RUN install_packages \
   # Intel GPU drivers for VLC
   i965-va-driver \
   vainfo \
-  vdpau-va-driver \
+  mesa-va-drivers \
   # Parse JSON for boot count
   jq
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -6,6 +6,9 @@ FROM balenalib/%%BALENA_ARCH%%-ubuntu-python:3.8-latest-run
 # for instance if you need git, just uncomment the line below.
 RUN install_packages \
   vlc \
+  vlc-plugin-base \
+  vlc-plugin-qt \
+  vlc-plugin-video-output \
   g++ \
   xserver-xorg-video-intel \
   xserver-xorg-input-evdev \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -25,6 +25,8 @@ RUN install_packages \
   i965-va-driver \
   vainfo \
   mesa-va-drivers \
+  # Avoid org.a11y.Bus error
+  at-spi2-core \
   # Parse JSON for boot count
   jq
 

--- a/scripts/first_boot.sh
+++ b/scripts/first_boot.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+echo "________Start of first_boot.sh________"
+
+BOOT_COUNT_RESPONSE=$(curl -sk http://bootcount:8082/api/count/)
+BOOT_COUNT=$(echo $BOOT_COUNT_RESPONSE | jq --raw-output '.count')
+
+if [[ $BOOT_COUNT == "1" ]]; then
+  # Restart the container
+  echo "This is the first boot, so restarting the interactive label container in 30 seconds to resolve the background image turning black..."
+  sleep 30
+  # Update the boot count
+  curl --request POST 'http://bootcount:8082/api/count/'
+  # Restart the interactive label container
+  curl -H "Content-Type: application/json" -d "{\"serviceName\": \"$BALENA_SERVICE_NAME\"}" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/restart-service?apikey=$BALENA_SUPERVISOR_API_KEY"
+else
+  echo "Boot count is $BOOT_COUNT so not restarting..."
+fi
+
+echo "________End of first_boot.sh________"

--- a/scripts/first_boot.sh
+++ b/scripts/first_boot.sh
@@ -7,11 +7,11 @@ BOOT_COUNT=$(echo $BOOT_COUNT_RESPONSE | jq --raw-output '.count')
 
 if [[ $BOOT_COUNT == "1" ]]; then
   # Restart the container
-  echo "This is the first boot, so restarting the interactive label container in 30 seconds to resolve the background image turning black..."
+  echo "This is the first boot, so restarting the media-player container in 30 seconds..."
   sleep 30
   # Update the boot count
   curl --request POST 'http://bootcount:8082/api/count/'
-  # Restart the interactive label container
+  # Restart the media-player container
   curl -H "Content-Type: application/json" -d "{\"serviceName\": \"$BALENA_SERVICE_NAME\"}" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/restart-service?apikey=$BALENA_SUPERVISOR_API_KEY"
 else
   echo "Boot count is $BOOT_COUNT so not restarting..."

--- a/scripts/pi.sh
+++ b/scripts/pi.sh
@@ -48,6 +48,11 @@ xset s off -dpms
 # Hide the cursor
 unclutter -idle 0.1 &
 
+# Start the first boot checker
+if [ -z "$DISABLE_FIRST_BOOT_CHECK" ]; then
+  ./scripts/first_boot.sh
+fi
+
 # rotate screen if env variable is set [normal, inverted, left or right]
 if [[ ! -z "$ROTATE_DISPLAY" ]]; then
   echo "Rotating display: ${ROTATE_DISPLAY}"

--- a/scripts/x86.sh
+++ b/scripts/x86.sh
@@ -52,6 +52,11 @@ xset s off -dpms
 # Hide the cursor
 unclutter -idle 0.1 &
 
+# Start the first boot checker
+if [ -z "$DISABLE_FIRST_BOOT_CHECK" ]; then
+  ./scripts/first_boot.sh
+fi
+
 # Set X background image
 xfconf-query --channel xfce4-desktop --property /backdrop/screen0/monitor0/workspace0/last-image --set /code/resources/blank-1920x1080.png
 


### PR DESCRIPTION
Resolves #188

Let's add the first boot checker from our Interactive Labels to Media Players to help resolve the first boot black screen reported occasionally by the AV team.

### Acceptance Criteria
- [x] Add [first boot checker](https://github.com/search?q=repo%3AACMILabs%2Finteractive-label%20first_boot&type=code) so they restart the `media-player` container on first boot

### Relevant design files
* None

### Testing instructions
1. Add your Raspberry Pi media player to the [Staging media player app](https://dashboard.balena-cloud.com/fleets/1505457)
1. Add your Intel media player to the [Staging media player app](https://dashboard.balena-cloud.com/fleets/1502473)
1. Watch the logs to see it reboot the `media-player` container on first boot